### PR TITLE
feat: add dive version config to analyze executor

### DIFF
--- a/packages/nx-docker/src/executors/analyze/executor.spec.ts
+++ b/packages/nx-docker/src/executors/analyze/executor.spec.ts
@@ -41,6 +41,7 @@ describe('Docker Analyze Executor', () => {
         lowestEfficiencyRatio: 0.8,
         source: '/source/path',
         ignoreError: true,
+        version: 'latest',
       };
       const args = getDiveArgs(options);
       expect(args).toEqual([
@@ -60,6 +61,7 @@ describe('Docker Analyze Executor', () => {
         image: 'test-image',
         source: '/source/path',
         ignoreError: false,
+        version: 'latest',
       };
       const args = getDiveArgs(options);
       expect(args).toEqual(['test-image', '--source=/source/path']);
@@ -73,6 +75,7 @@ describe('Docker Analyze Executor', () => {
         image: 'test-image',
         source: '/source/path',
         ignoreError: false,
+        version: 'latest',
       };
       const result = await executor(options, context);
       expect(result).toEqual({ success: true });
@@ -86,6 +89,7 @@ describe('Docker Analyze Executor', () => {
         image: 'test-image',
         source: '/source/path',
         ignoreError: false,
+        version: 'latest',
       };
       const result = await executor(options, context);
       expect(result).toEqual({ success: false });
@@ -102,7 +106,6 @@ describe('Docker Analyze Executor', () => {
         'lowestEfficiencyRatio',
       ];
       for (let i = 0; i < optionsToChecks.length; i++) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const options: any = {
           ci: false,
           image: 'test-image',
@@ -124,6 +127,7 @@ describe('Docker Analyze Executor', () => {
         image: 'test-image',
         source: '/source/path',
         ignoreError: true,
+        version: 'latest',
       };
       await executor(options, context);
       expect(execFileSync).toHaveBeenCalledWith(
@@ -139,6 +143,7 @@ describe('Docker Analyze Executor', () => {
         image: 'test-image',
         source: '/source/path',
         ignoreError: true,
+        version: 'latest',
       };
       await executor(options, context);
       expect(execFileSync).toHaveBeenCalledWith(
@@ -154,11 +159,28 @@ describe('Docker Analyze Executor', () => {
         image: 'test-image',
         source: '/source/path',
         ignoreError: true,
+        version: 'latest',
       };
       await executor(options, context);
       expect(execFileSync).toHaveBeenCalledWith(
         'docker',
         expect.arrayContaining(['-ti']),
+        expect.anything()
+      );
+    });
+
+    it('should set version of dive', async () => {
+      const options: AnalyzeExecutorSchema = {
+        ci: false,
+        image: 'test-image',
+        source: '/source/path',
+        ignoreError: true,
+        version: '1.0.0',
+      };
+      await executor(options, context);
+      expect(execFileSync).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.arrayContaining(['wagoodman/dive:1.0.0']),
         expect.anything()
       );
     });
@@ -169,6 +191,7 @@ describe('Docker Analyze Executor', () => {
         image: 'test-image',
         source: '/source/path',
         ignoreError: false,
+        version: 'latest',
       };
       (execFileSync as jest.Mock).mockImplementation(() => {
         throw new Error('Docker error');

--- a/packages/nx-docker/src/executors/analyze/executor.ts
+++ b/packages/nx-docker/src/executors/analyze/executor.ts
@@ -60,7 +60,7 @@ const executor: PromiseExecutor<AnalyzeExecutorSchema> = async (options, context
     ...(options.ci ? ['--rm'] : ['-ti', '--rm']),
     '-v',
     `${dockerLocalSocket}:/var/run/docker.sock`,
-    'wagoodman/dive',
+    `wagoodman/dive:${options.version}`,
   ];
   const diveArgs = getDiveArgs(options);
 

--- a/packages/nx-docker/src/executors/analyze/schema.d.ts
+++ b/packages/nx-docker/src/executors/analyze/schema.d.ts
@@ -7,4 +7,5 @@ export interface AnalyzeExecutorSchema {
   source: string;
   image: string;
   dockerSocket?: string;
+  version: string;
 }

--- a/packages/nx-docker/src/executors/analyze/schema.json
+++ b/packages/nx-docker/src/executors/analyze/schema.json
@@ -38,6 +38,11 @@
     "dockerSocket": {
       "type": "string",
       "description": "The docker socket to use for the analysis"
+    },
+    "version": {
+      "type": "string",
+      "description": "The version of dive to use",
+      "default": "latest"
     }
   },
   "required": ["image"]

--- a/packages/nx-docker/src/executors/build/executor.spec.ts
+++ b/packages/nx-docker/src/executors/build/executor.spec.ts
@@ -109,11 +109,10 @@ describe('executor', () => {
     expect(logger.warn).toHaveBeenCalledWith(
       'Buildx is not installed falling back to docker build. Docker buildx is not installed so performance may be degraded'
     );
-    expect(execFileSync).toHaveBeenCalledWith(
-      "docker",
-      expect.arrayContaining(['build']),
-      { stdio: 'inherit', cwd: context.root }
-    );
+    expect(execFileSync).toHaveBeenCalledWith('docker', expect.arrayContaining(['build']), {
+      stdio: 'inherit',
+      cwd: context.root,
+    });
   });
 
   it('should return failure if project name is missing', async () => {
@@ -158,7 +157,7 @@ describe('executor', () => {
 
   it('should build Docker image with provided tags and build args', async () => {
     // Arrange
-    const expectedCommand = 'docker'
+    const expectedCommand = 'docker';
     const expectedCommandArgs = [
       'buildx',
       'build',
@@ -175,7 +174,10 @@ describe('executor', () => {
     await executor(options, context);
 
     // Assert
-    expect(execFileSync).toHaveBeenCalledWith(expectedCommand, expectedCommandArgs, { stdio: 'inherit', cwd: context.root });
+    expect(execFileSync).toHaveBeenCalledWith(expectedCommand, expectedCommandArgs, {
+      stdio: 'inherit',
+      cwd: context.root,
+    });
   });
 
   it('should log failure if Docker build fails', async () => {
@@ -198,11 +200,10 @@ describe('executor', () => {
     await executor(options, context);
 
     const expectedTagArgs = ['-t', 'latest', '-t', 'v1.0.0'];
-    expect(execFileSync).toHaveBeenCalledWith(
-      "docker",
-      expect.arrayContaining(expectedTagArgs),
-      { stdio: 'inherit', cwd: context.root }
-    );
+    expect(execFileSync).toHaveBeenCalledWith('docker', expect.arrayContaining(expectedTagArgs), {
+      stdio: 'inherit',
+      cwd: context.root,
+    });
   });
 
   it('should build Docker image with build arguments when args are provided', async () => {
@@ -211,11 +212,10 @@ describe('executor', () => {
     await executor(options, context);
 
     const expectedBuildArgs = ['--build-arg', 'ARG1=value1', '--build-arg', 'ARG2=value2'];
-    expect(execFileSync).toHaveBeenCalledWith(
-      "docker",
-      expect.arrayContaining(expectedBuildArgs),
-      { stdio: 'inherit', cwd: context.root}
-    );
+    expect(execFileSync).toHaveBeenCalledWith('docker', expect.arrayContaining(expectedBuildArgs), {
+      stdio: 'inherit',
+      cwd: context.root,
+    });
   });
 
   it('should not add build arguments if args are not provided', async () => {
@@ -224,7 +224,7 @@ describe('executor', () => {
     await executor(options, context);
 
     expect(execFileSync).toHaveBeenCalledWith(
-      "docker",
+      'docker',
       expect.not.arrayContaining(['--build-arg']),
       { stdio: 'inherit', cwd: context.root }
     );

--- a/packages/nx-docker/src/executors/build/executor.ts
+++ b/packages/nx-docker/src/executors/build/executor.ts
@@ -1,39 +1,41 @@
 import { logger, PromiseExecutor } from '@nx/devkit';
 import { join } from 'path';
+import { DockerExecutorSchema } from './schema';
+import { DockerUtils } from '../../utils/docker.utils';
 import { existsSync } from 'fs';
+import { ProjectUtils } from '../../utils/project.utils';
 import { execFileSync } from 'child_process';
 
-import { DockerExecutorSchema } from './schema';
-
 const executor: PromiseExecutor<DockerExecutorSchema> = async (options, context) => {
-  try {
-    execFileSync('docker', ['info'], { stdio: context.isVerbose ? 'inherit' : 'ignore' });
-  } catch {
+  const dockerService = new DockerUtils();
+
+  // Check docker installed and docker daemon is running
+  if (!dockerService.checkDockerInstalled(context.isVerbose)) {
     logger.error('Docker is not installed or docker daemon is not running');
     return { success: false };
   }
 
-  let buildCommand = ['docker', 'build'];
-  try {
-    execFileSync('docker', ['buildx', 'version'], {
-      stdio: context.isVerbose ? 'inherit' : 'ignore',
-    });
-    buildCommand = ['docker', 'buildx', 'build'];
-  } catch {
-    logger.warn('Docker buildx is not installed so performance may be degraded');
+  // Determine using build or buildx for building Docker image
+  const isBuildxInstalled = dockerService.checkBuildxInstalled(context.isVerbose);
+  if (!isBuildxInstalled) {
+    logger.warn(
+      'Buildx is not installed falling back to docker build. Docker buildx is not installed so performance may be degraded'
+    );
   }
+  const buildCommand = isBuildxInstalled ? ['docker', 'buildx', 'build'] : ['docker', 'build'];
 
-  const projectName = context.projectName;
-  if (!projectName) {
-    logger.error('No project name provided');
+  let projectUtils;
+  try {
+    projectUtils = new ProjectUtils(context);
+  } catch (error: unknown) {
+    logger.fatal('No project name provided', error);
     return { success: false };
   }
 
-  const projectConfig = context.projectsConfigurations.projects[projectName];
-  const projectRoot = projectConfig.root;
-  const dockerfilePath = options.file || join(projectRoot, 'Dockerfile');
+  const dockerfilePath = options.file || join(projectUtils.getProjectRoot(), 'Dockerfile');
   const contextPath = options.context || '.';
 
+  // Kiểm tra Dockerfile và context
   if (!existsSync(dockerfilePath)) {
     logger.error(`Dockerfile not found at ${dockerfilePath}`);
     return { success: false };
@@ -44,22 +46,13 @@ const executor: PromiseExecutor<DockerExecutorSchema> = async (options, context)
     return { success: false };
   }
 
-  const tagArgs = [];
-  if (options.tags) {
-    for (const tag of options.tags) {
-      tagArgs.push('-t', tag);
-    }
-  }
-
-  const buildArgs = [];
-  const args = options.args || [];
-  for (const arg of args) {
-    buildArgs.push('--build-arg', arg);
-  }
+  // Build tag và build arg
+  const tagArgs = options.tags.flatMap((tag) => ['-t', tag]);
+  const buildArgs = options.args?.flatMap((arg) => ['--build-arg', arg]) || [];
 
   try {
     const command = [...buildCommand, ...buildArgs, ...tagArgs, '-f', dockerfilePath, contextPath];
-    logger.info(`Build command: ${command.join(' ')}`);
+    logger.info(`${command.join(' ')}\n`);
     execFileSync(command[0], command.slice(1), { stdio: 'inherit', cwd: context.root });
     return { success: true };
   } catch (error) {

--- a/packages/nx-docker/src/executors/build/schema.d.ts
+++ b/packages/nx-docker/src/executors/build/schema.d.ts
@@ -2,7 +2,7 @@ export interface DockerExecutorSchema {
   ci: boolean;
   file?: string;
   context?: string;
-  args: Array<string>;
+  args?: Array<string>;
   outputs: Array<string>;
   tags: Array<string>;
 }

--- a/packages/nx-docker/src/utils/docker.utils.spec.ts
+++ b/packages/nx-docker/src/utils/docker.utils.spec.ts
@@ -1,0 +1,77 @@
+// docker-service.spec.ts
+import { DockerUtils } from './docker.utils';
+import { execFileSync } from 'child_process';
+
+// Mock execFileSync function
+jest.mock('child_process', () => ({
+  execFileSync: jest.fn(),
+}));
+
+describe('DockerService', () => {
+  let dockerService: DockerUtils;
+
+  beforeEach(() => {
+    dockerService = new DockerUtils();
+    jest.resetAllMocks();
+  });
+
+  describe('checkDockerInstalled', () => {
+    it('should return true if Docker is installed', () => {
+      // Arrange: execFileSync sẽ không ném ra lỗi
+      (execFileSync as jest.Mock).mockImplementation(() => true);
+
+      // Act
+      const result = dockerService.checkDockerInstalled(true);
+
+      // Assert
+      expect(result).toBe(true);
+      expect(execFileSync).toHaveBeenCalledWith('docker', ['info'], { stdio: 'inherit' });
+    });
+
+    it('should return false if Docker is not installed or daemon is not running', () => {
+      // Arrange: execFileSync sẽ ném ra lỗi
+      (execFileSync as jest.Mock).mockImplementation(() => {
+        throw new Error();
+      });
+
+      // Act
+      const result = dockerService.checkDockerInstalled(false);
+
+      // Assert
+      expect(result).toBe(false);
+      expect(execFileSync).toHaveBeenCalledWith('docker', ['info'], { stdio: 'ignore' });
+    });
+  });
+
+  describe('checkBuildxInstalled', () => {
+    it('should return true if Docker buildx is installed', () => {
+      // Arrange
+      (execFileSync as jest.Mock).mockImplementation(() => true);
+
+      // Act
+      const result = dockerService.checkBuildxInstalled(true);
+
+      // Assert
+      expect(result).toBe(true);
+      expect(execFileSync).toHaveBeenCalledWith('docker', ['buildx', 'version'], {
+        stdio: 'inherit',
+      });
+    });
+
+    it('should return false if Docker buildx is not installed', () => {
+      // Arrange
+      (execFileSync as jest.Mock).mockImplementation(() => {
+        throw new Error();
+      });
+
+      // Act
+      const result = dockerService.checkBuildxInstalled(false);
+
+      // Assert
+      expect(result).toBe(false);
+      expect(execFileSync).toHaveBeenCalledWith('docker', ['buildx', 'version'], {
+        stdio: 'ignore',
+      });
+    });
+  });
+});

--- a/packages/nx-docker/src/utils/docker.utils.ts
+++ b/packages/nx-docker/src/utils/docker.utils.ts
@@ -1,0 +1,22 @@
+// docker-service.ts
+import { execFileSync } from 'child_process';
+
+export class DockerUtils {
+  checkDockerInstalled(verbose: boolean): boolean {
+    try {
+      execFileSync('docker', ['info'], { stdio: verbose ? 'inherit' : 'ignore' });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  checkBuildxInstalled(verbose: boolean): boolean {
+    try {
+      execFileSync('docker', ['buildx', 'version'], { stdio: verbose ? 'inherit' : 'ignore' });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/nx-docker/src/utils/project.utils.spec.ts
+++ b/packages/nx-docker/src/utils/project.utils.spec.ts
@@ -1,0 +1,72 @@
+// project-utils.spec.ts
+import { ExecutorContext } from '@nx/devkit';
+import { ProjectUtils } from './project.utils';
+
+describe('ProjectUtils', () => {
+  let projectUtils: ProjectUtils;
+  const context: ExecutorContext = {
+    isVerbose: false,
+    projectName: 'test-project',
+    projectsConfigurations: {
+      version: 1,
+      projects: {
+        'test-project': {
+          root: '/root/test-project',
+        },
+      },
+    },
+    root: '/root',
+    nxJsonConfiguration: {},
+    cwd: '/root',
+    projectGraph: {
+      nodes: {},
+      dependencies: {},
+    },
+  };
+
+  beforeEach(() => {
+    projectUtils = new ProjectUtils(context);
+  });
+
+  describe('constructor', () => {
+    it('should throw an error if project name is not provided', () => {
+      // Arrange: create context without projectName
+      const invalidContext = { ...context, projectName: undefined };
+
+      // Act & Assert
+      expect(() => new ProjectUtils(invalidContext as ExecutorContext)).toThrow(
+        'No project name provided'
+      );
+    });
+  });
+
+  describe('getProjectName', () => {
+    it('should return the project name', () => {
+      // Act
+      const projectName = projectUtils.getProjectName();
+
+      // Assert
+      expect(projectName).toBe('test-project');
+    });
+  });
+
+  describe('getProjectConfig', () => {
+    it('should return the project configuration', () => {
+      // Act
+      const projectConfig = projectUtils.getProjectConfig();
+
+      // Assert
+      expect(projectConfig).toEqual({ root: '/root/test-project' });
+    });
+  });
+
+  describe('getProjectRoot', () => {
+    it('should return the project root path', () => {
+      // Act
+      const projectRoot = projectUtils.getProjectRoot();
+
+      // Assert
+      expect(projectRoot).toBe('/root/test-project');
+    });
+  });
+});

--- a/packages/nx-docker/src/utils/project.utils.ts
+++ b/packages/nx-docker/src/utils/project.utils.ts
@@ -1,4 +1,4 @@
-import { ExecutorContext } from '@nx/devkit';
+import { ExecutorContext, ProjectConfiguration } from '@nx/devkit';
 
 export class ProjectUtils {
   private projectName: string;
@@ -12,11 +12,11 @@ export class ProjectUtils {
   }
 
   public getProjectName(): string {
-    return this.projectName!;
+    return this.projectName;
   }
 
-  public getProjectConfig(): any {
-    return this.context.projectsConfigurations.projects[this.projectName!];
+  public getProjectConfig(): ProjectConfiguration {
+    return this.context.projectsConfigurations.projects[this.projectName];
   }
 
   public getProjectRoot(): string {

--- a/packages/nx-docker/src/utils/project.utils.ts
+++ b/packages/nx-docker/src/utils/project.utils.ts
@@ -1,0 +1,25 @@
+import { ExecutorContext } from '@nx/devkit';
+
+export class ProjectUtils {
+  private projectName: string;
+
+  constructor(private context: ExecutorContext) {
+    const projectName = context.projectName;
+    if (!projectName) {
+      throw new Error('No project name provided');
+    }
+    this.projectName = projectName;
+  }
+
+  public getProjectName(): string {
+    return this.projectName!;
+  }
+
+  public getProjectConfig(): any {
+    return this.context.projectsConfigurations.projects[this.projectName!];
+  }
+
+  public getProjectRoot(): string {
+    return this.getProjectConfig().root;
+  }
+}


### PR DESCRIPTION
This pull request includes significant updates to the Docker analyze and build executors, focusing on refactoring, adding new functionality, and improving error handling.

### Docker Analyze Executor Enhancements:
* Refactored the analyze executor to use a new `DockerUtils` class for checking Docker installation and running status.
* Added a new `getDiveArgs` function to build arguments for the `dive` tool, supporting both CI and non-CI modes.
* Enhanced error handling and logging for unsupported options in non-CI mode.
* Introduced a new `version` option in the schema to specify the version of `dive` to use.

### Docker Build Executor Enhancements:
* Refactored the build executor to use `DockerUtils` for checking Docker and Buildx installations.
* Improved error handling and logging for missing Dockerfile, context path, and project name.
* Added support for specifying Docker build arguments and tags dynamically.

These changes enhance the robustness and flexibility of the Docker executors, making them more reliable and easier to maintain.