### PR TITLE
feat(nx-docker): add some options to nx docker build

### DIFF
--- a/packages/nx-docker/src/executors/build/executor.spec.ts
+++ b/packages/nx-docker/src/executors/build/executor.spec.ts
@@ -161,6 +161,7 @@ describe('executor', () => {
     const expectedCommandArgs = [
       'buildx',
       'build',
+      '--output=image',
       '--build-arg',
       'ARG1=value1',
       '-t',

--- a/packages/nx-docker/src/executors/build/executor.ts
+++ b/packages/nx-docker/src/executors/build/executor.ts
@@ -47,11 +47,44 @@ const executor: PromiseExecutor<DockerExecutorSchema> = async (options, context)
   }
 
   // Build tag và build arg
-  const tagArgs = options.tags.flatMap((tag) => ['-t', tag]);
+  const outputArgs = options.outputs ? [`--output=${options.outputs.join(',')}`] : [];
+  const cacheFromArgs =
+    options.cacheFrom && options.cacheFrom.length > 0
+      ? [`--cache-from=${options.cacheFrom.join(',')}`]
+      : [];
+  const cacheToArgs =
+    options.cacheFrom && options.cacheFrom.length > 0
+      ? [`--cache-to=${options.cacheFrom.join(',')}`]
+      : [];
+  const tagArgs = options.tags.flatMap((tag) => ['-t', tag]) || [];
   const buildArgs = options.args?.flatMap((arg) => ['--build-arg', arg]) || [];
-
+  const addHostArgs = options.addHost?.flatMap((host) => ['--add-host', host]) || [];
+  const allowArgs = options.allow?.flatMap((allow) => ['--allow', allow]) || [];
+  const annotationArgs =
+    options.annotation?.flatMap((annotation) => ['--annotation', annotation]) || [];
+  const attestArgs = options.attest?.flatMap((attest) => ['--attest', attest]) || [];
+  const shmSizeArgs = options.shmSize ? ['--shm-size', options.shmSize] : [];
+  const uLimitArgs = options.ulimit ? [`--ulimit${options.ulimit}`] : [];
+  const targetArgs = options.target ? ['--target', options.target] : [];
   try {
-    const command = [...buildCommand, ...buildArgs, ...tagArgs, '-f', dockerfilePath, contextPath];
+    const command = [
+      ...buildCommand,
+      ...outputArgs,
+      ...cacheFromArgs,
+      ...cacheToArgs,
+      ...buildArgs,
+      ...addHostArgs,
+      ...allowArgs,
+      ...annotationArgs,
+      ...attestArgs,
+      ...shmSizeArgs,
+      ...uLimitArgs,
+      ...tagArgs,
+      ...targetArgs,
+      '-f',
+      dockerfilePath,
+      contextPath,
+    ];
     logger.info(`${command.join(' ')}\n`);
     execFileSync(command[0], command.slice(1), { stdio: 'inherit', cwd: context.root });
     return { success: true };

--- a/packages/nx-docker/src/executors/build/schema.d.ts
+++ b/packages/nx-docker/src/executors/build/schema.d.ts
@@ -5,4 +5,13 @@ export interface DockerExecutorSchema {
   args?: Array<string>;
   outputs: Array<string>;
   tags: Array<string>;
+  addHost?: string[];
+  allow?: string[];
+  annotation?: string[];
+  attest?: string[];
+  cacheFrom?: string[];
+  cacheTo?: string[];
+  shmSize?: string;
+  target?: string;
+  ulimit?: string[];
 }

--- a/packages/nx-docker/src/executors/build/schema.json
+++ b/packages/nx-docker/src/executors/build/schema.json
@@ -36,7 +36,64 @@
         "type": "string"
       },
       "description": "The tag of the image to build"
+    },
+    "addHost": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Add a custom host-to-IP mapping (host:ip)"
+    },
+    "allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Allow extra privileged entitlement (e.g., network.host, security.insecure)"
+    },
+    "annotation": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Set metadata for an image"
+    },
+    "attest": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Attest the image with an attestation provider"
+    },
+    "cacheFrom": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Images to consider as cache sources"
+    },
+    "cacheTo": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Images to consider as cache destinations"
+    },
+    "shm-size": {
+      "type": "string",
+      "description": "Size of /dev/shm"
+    },
+    "target": {
+      "type": "string",
+      "description": "Set the target build stage to build"
+    },
+    "ulimit": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Ulimit options"
     }
   },
-  "required": ["outputs", "tags"]
+  "required": ["tags"]
 }


### PR DESCRIPTION
This pull request enhances the Docker executor by adding several new configuration options and improving the command construction logic. The most important changes include adding support for various Docker build arguments and updating the schema to include these new options.

### Enhancements to Docker executor:

* Added support for new Docker build arguments including `addHost`, `allow`, `annotation`, `attest`, `cacheFrom`, `cacheTo`, `shmSize`, and `ulimit` in the `executor.ts` file.
* Updated the `schema.json` file to include definitions for the new Docker build arguments.

### Improvements to command construction:

* Modified the command construction logic in the `executor.ts` file to include the new Docker build arguments in the final command array.

### Test updates:

* Updated the `executor.spec.ts` file to reflect the changes in the expected command arguments.