### PR TITLE
test: fix e2e test

### DIFF
--- a/e2e/nx-docker-e2e/project.json
+++ b/e2e/nx-docker-e2e/project.json
@@ -9,7 +9,7 @@
       "executor": "@ebizbase/nx-docker:build",
       "options": {
         "tags": ["nx-docker-e2e:test"],
-        "outputs": ["image"],
+        "outputs": ["type=docker"],
         "args": ["ALPINE_VERSION=3.12"]
       }
     },
@@ -17,7 +17,7 @@
       "dependsOn": ["nx-docker-e2e:build"],
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker run --rm main-spec:test curl --version"
+        "command": "docker run --rm nx-docker-e2e:test curl --version"
       }
     },
     "analyze-test": {

--- a/packages/nx-docker/README.md
+++ b/packages/nx-docker/README.md
@@ -30,7 +30,7 @@ Bellow config simple build docker image and load it in local registry. You can s
       "executor": "@ebizbase/nx-docker:build",
       "options": {
         "tags": ["your-app:latest"],
-        "outputs": ["image"]
+        "outputs": ["type=image"]
       }
     }
   }
@@ -46,7 +46,7 @@ If you want to build and push image let referance bellow example
       "executor": "@ebizbase/nx-docker:build",
       "options": {
         "tags": ["docker.io/org/your-app:latest", "ghcr.io/ogr/your-app:latest"],
-        "outputs": ["registry"]
+        "outputs": ["type=registry"]
       }
     }
   }


### PR DESCRIPTION
This pull request includes changes to the `nx-docker` package and an end-to-end test configuration. The most important changes involve updating the `outputs` options to include the type specifier and correcting a command in the project configuration.

Updates to `nx-docker` package:

* [`packages/nx-docker/README.md`](diffhunk://#diff-b7a3edb30e4bed0bac59f577f1ab29b1aed1644fcaa5e303a2cc205130fdba02L33-R33): Changed `outputs` options to include the type specifier for building image and pushing to registry. [[1]](diffhunk://#diff-b7a3edb30e4bed0bac59f577f1ab29b1aed1644fcaa5e303a2cc205130fdba02L33-R33) [[2]](diffhunk://#diff-b7a3edb30e4bed0bac59f577f1ab29b1aed1644fcaa5e303a2cc205130fdba02L49-R49)

Corrections in project configuration:

* [`e2e/nx-docker-e2e/project.json`](diffhunk://#diff-25bb8ec9f94af5f1fa66b624d93a2fc2064620224769b536450769ff1c2eb968L12-R20): Updated `outputs` option from `["image"]` to `["type=docker"]` and corrected the Docker run command to use the appropriate tag.