### PR TITLE
feat(nx-docker): add option metadataFile and flatforms to build executor

### DIFF
--- a/e2e/nx-docker-e2e/project.json
+++ b/e2e/nx-docker-e2e/project.json
@@ -10,14 +10,19 @@
       "options": {
         "tags": ["nx-docker-e2e:test"],
         "outputs": ["type=docker"],
-        "args": ["ALPINE_VERSION=3.12"]
+        "args": ["ALPINE_VERSION=3.12"],
+        "metadataFile": "dist/e2e/nx-docker-e2e/metadata.json"
       }
     },
     "build-test": {
       "dependsOn": ["nx-docker-e2e:build"],
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker run --rm nx-docker-e2e:test curl --version"
+        "commands": [
+          "docker run --rm nx-docker-e2e:test curl --version",
+          "cat dist/e2e/nx-docker-e2e/metadata.json | jq ."
+        ],
+        "parallel": false
       }
     },
     "analyze-test": {

--- a/packages/nx-docker/README.md
+++ b/packages/nx-docker/README.md
@@ -74,6 +74,21 @@ Bellow is all options of @ebizbase/nx-docker:build
 | `shm-size`   | string   | Size of /dev/shm                                                           |         | No       |
 | `target`     | string   | Set the target build stage to build                                        |         | No       |
 | `ulimit`     | string[] | Ulimit options                                                             |         | No       |
+| `platform`   | string[] | Set the target platform for the build                                      |         | No       |
+| `ulimit`     | string[] | The metadata will be written as a JSON object to the specified file.       |         | No       |
+
+> `shm-size` and `ulimit` are only available using `moby/buildkit:master`
+> as builder image atm:
+>
+> ```yaml
+> - name: Set up Docker Buildx
+>   uses: docker/setup-buildx-action@v1
+>   with:
+>   driver-opts: |
+>     image=moby/buildkit:master
+> ```
+
+To check all possible options please check this [schema.json](./src/executors/build/schema.json) file
 
 ## Analyze image
 

--- a/packages/nx-docker/src/executors/build/executor.spec.ts
+++ b/packages/nx-docker/src/executors/build/executor.spec.ts
@@ -51,6 +51,7 @@ describe('executor', () => {
     args: ['ARG1=value1'],
     ci: false,
     outputs: ['image'],
+    flatforms: [],
   };
   let dockerUtils: jest.Mocked<DockerUtils>;
   let projectUtils: jest.Mocked<ProjectUtils>;

--- a/packages/nx-docker/src/executors/build/schema.d.ts
+++ b/packages/nx-docker/src/executors/build/schema.d.ts
@@ -14,4 +14,6 @@ export interface DockerExecutorSchema {
   shmSize?: string;
   target?: string;
   ulimit?: string[];
+  metadataFile?: string;
+  flatforms: string[];
 }

--- a/packages/nx-docker/src/executors/build/schema.json
+++ b/packages/nx-docker/src/executors/build/schema.json
@@ -79,7 +79,7 @@
       },
       "description": "Images to consider as cache destinations"
     },
-    "shm-size": {
+    "shmSize": {
       "type": "string",
       "description": "Size of /dev/shm"
     },
@@ -93,6 +93,14 @@
         "type": "string"
       },
       "description": "Ulimit options"
+    },
+    "metadataFile": {
+      "type": "string",
+      "description": "The metadata will be written as a JSON object to the specified file"
+    },
+    "flatforms": {
+      "type": "string",
+      "description": "Set the target platform"
     }
   },
   "required": ["tags"]


### PR DESCRIPTION
This pull request introduces several enhancements and bug fixes to the `nx-docker` package, including updates to the build executor, schema, and documentation. The most important changes involve the addition of new options for metadata file handling and platform targeting, as well as improvements to the build process.

### Enhancements to build executor and schema:

* Added support for specifying a metadata file and ensuring its directory exists before writing to it in `executor.ts`. [[1]](diffhunk://#diff-2dc6919f390f2121d911f845de56c55137a6fd2a1923a349be1ecc2bff197fe7R59-R71) [[2]](diffhunk://#diff-2dc6919f390f2121d911f845de56c55137a6fd2a1923a349be1ecc2bff197fe7R82-R90)
* Introduced `metadataFile` and `flatforms` options in `schema.json`.

### Documentation updates:

* Updated `README.md` to include new options `platform` and `metadataFile`, and provided instructions for using `moby/buildkit:master` as the builder image.

### Test updates:

* Added `flatforms` to the default options in `executor.spec.ts`.

### Miscellaneous changes:

* Fixed typo in `schema.json` by renaming `shm-size` to `shmSize`.
* Added `mkdirSync` import in `executor.ts` to support metadata file creation.

### e2e test configuration:

* Modified `project.json` to include metadata file handling and updated test commands to check metadata.